### PR TITLE
Update: Set -std=c99 for linux build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": [
         ["bash", "-c", "echo", "#{os}"],
         ["bash", "-c", "#{os == 'windows' ? 'CC=x86_64-w64-mingw32-gcc script/build-lib' : 'echo'}"],
-        ["bash", "-c", "#{os == 'linux' ? 'CC=gcc CFLAGS=-fPIC script/build-lib' : 'echo'}"],
+        ["bash", "-c", "#{os == 'linux' ? 'CC=gcc CFLAGS=\"-fPIC -std=c99\" script/build-lib' : 'echo'}"],
         ["bash", "-c", "#{os == 'darwin' ? 'CC=gcc script/build-lib' : 'echo'}"],
         ["bash", "-c", "#{os == 'macOS' ? 'CC=gcc script/build-lib' : 'echo'}"]
     ],


### PR DESCRIPTION
The tree-sitter build was failing on CentOS for me with the latest update - this adds the `-std=c99` flag to get it building on CentOS